### PR TITLE
Allow customization of the hook URL by exposing a`DRONE_HOOK_HOST` parameter.

### DIFF
--- a/cmd/drone-server/server.go
+++ b/cmd/drone-server/server.go
@@ -52,6 +52,12 @@ var flags = []cli.Flag{
 		Value:  ":8000",
 	},
 	cli.StringFlag{
+		EnvVar: "DRONE_HOOK_HOST",
+		Name:   "hook-host",
+		Usage:  "for generating webhook links",
+		Value:  "",
+	},
+	cli.StringFlag{
 		EnvVar: "DRONE_SERVER_CERT",
 		Name:   "server-cert",
 		Usage:  "server ssl cert",
@@ -489,6 +495,12 @@ func server(c *cli.Context) error {
 		)
 	}
 
+	if c.String("hook-host") != "" && !strings.Contains(c.String("hook-host"), "://") {
+		logrus.Fatalln(
+			"HOOK_HOST must be <scheme>://<hostname> format",
+		)
+	}
+
 	remote_, err := SetupRemote(c)
 	if err != nil {
 		logrus.Fatal(err)
@@ -648,6 +660,7 @@ func setupEvilGlobals(c *cli.Context, v store.Store, r remote.Remote) {
 	droneserver.Config.Server.Pass = c.String("agent-secret")
 	droneserver.Config.Server.Host = strings.TrimRight(c.String("server-host"), "/")
 	droneserver.Config.Server.Port = c.String("server-addr")
+	droneserver.Config.Server.HookHost = strings.TrimRight(c.String("hook-host"), "/")
 	droneserver.Config.Server.RepoConfig = c.String("repo-config")
 	droneserver.Config.Server.SessionExpires = c.Duration("session-expires")
 	droneserver.Config.Pipeline.Networks = c.StringSlice("network")

--- a/server/repo.go
+++ b/server/repo.go
@@ -17,6 +17,14 @@ import (
 	"github.com/drone/drone/store"
 )
 
+func getHookHost(r *http.Request) string {
+	if Config.Server.HookHost != "" {
+		return Config.Server.HookHost
+	}
+
+	return httputil.GetURL(r)
+}
+
 func PostRepo(c *gin.Context) {
 	remote := remote.FromContext(c)
 	user := session.User(c)
@@ -66,7 +74,7 @@ func PostRepo(c *gin.Context) {
 
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
-		httputil.GetURL(c.Request),
+		getHookHost(c.Request),
 		sig,
 	)
 
@@ -209,7 +217,7 @@ func RepairRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := httputil.GetURL(c.Request)
+	host := getHookHost(c.Request)
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
 		host,
@@ -295,7 +303,7 @@ func MoveRepo(c *gin.Context) {
 	}
 
 	// reconstruct the link
-	host := httputil.GetURL(c.Request)
+	host := getHookHost(c.Request)
 	link := fmt.Sprintf(
 		"%s/hook?access_token=%s",
 		host,

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -62,6 +62,7 @@ var Config = struct {
 		Pass           string
 		RepoConfig     string
 		SessionExpires time.Duration
+		HookHost       string
 		// Open bool
 		// Orgs map[string]struct{}
 		// Admins map[string]struct{}


### PR DESCRIPTION
@iterion This incorporates your suggestion of making the `getHookHost` function private.